### PR TITLE
Show next SS's dots as a guide and focus on selected dots

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,8 @@
     <ControlMenu />
     <h2>Grapher</h2>
     <p>Click a dot to select it.</p>
+    <p>Black dots reprsent a marcher at the current beat.</p>
+    <p>Red dots represent the next stuntsheet's position.</p>
     <div
     class="grapher-container"
     v-bind:style="{fontSize: zoomLevel + '%'}"

--- a/src/components/ControlMenu.vue
+++ b/src/components/ControlMenu.vue
@@ -4,11 +4,11 @@
     <h2>Control Menu</h2>
     <div>
       <label for="zoom-level">Zoom Level</label>
-      <input id="zoom-level" v-model.number="zoomLevel" type="number" />
+      <input id="zoom-level" v-model.number="zoomLevel" type="number" min="1" />
     </div>
     <div>
       <label for="beat-selector">Beat:</label>
-      <input id="beat-selector" v-model.number="selectedBeat" type="number" />
+      <input id="beat-selector" v-model.number="selectedBeat" type="number" min="0" v-bind:max="selectedSSBeats-1" />
       <span>of {{selectedSSBeats}}</span>
     </div>
   </div>
@@ -41,7 +41,7 @@ export default class BottomMenu extends Vue {
   }
 
   get selectedSSBeats () {
-    return this.$store.state.selectedSS.beats
+    return this.$store.getters.getSelectedSS.beats
   }
 }
 </script>

--- a/src/components/DotEditor.vue
+++ b/src/components/DotEditor.vue
@@ -1,33 +1,34 @@
 <template>
   <div>
     <div>
-      <h2>Dot Editor</h2>
-      <p>Click a row to select a dot.</p>
+      <h2>Selected Dot Editor</h2>
+      <p>Selected dots in the Grapher show up here.</p>
       <table>
         <thead>
           <tr>
-            <th>X / Y</th>
+            <th>From X/Y</th>
+            <th>To X/Y</th>
             <th>Dot Type</th>
             <th>Flow</th>
-            <th>Flow is valid</th>
           </tr>
         </thead>
         <tbody>
           <tr
-          v-for="(dot, index) in dots"
-          v-bind:class="{'selected': isSelected(dot)}"
-          v-on:click="setSelectedDots([dot])"
+          v-for="(dotPair, index) in dotsPairs"
           v-bind:key="index"
           >
             <td>
-              <input v-model.number="dot.coord[0]" type="number" />
-              <input v-model.number="dot.coord[1]" type="number" />
+              <input v-model.number="dotPair[0].coord[0]" v-on:change="generateFlowHelper(index)" type="number" />
+              <input v-model.number="dotPair[0].coord[1]" v-on:change="generateFlowHelper(index)" type="number" />
             </td>
             <td>
-              <input v-model.number="dot.dotType" type="number" />
+              <input v-if="dotPair[1]" v-model.number="dotPair[1].coord[0]" v-on:change="generateFlowHelper(index)" type="number" />
+              <input v-if="dotPair[1]" v-model.number="dotPair[1].coord[1]" v-on:change="generateFlowHelper(index)" type="number" />
             </td>
-            <td>{{dot.flow}}</td>
-            <td>{{dot.flowIsValid()}}</td>
+            <td>
+              <input v-model.number="dotPair[0].dotType" v-on:change="generateFlowHelper(index)" type="number" min="0" v-bind:max="dotTypesLength-1" />
+            </td>
+            <td>{{dotPair[0].flow}}</td>
           </tr>
         </tbody>
       </table>
@@ -39,20 +40,26 @@
 import { Component, Vue } from 'vue-property-decorator'
 import Stuntsheet from '@/models/Stuntsheet'
 import Dot from '@/models/Dot'
+import generateFlow from '@/logic/GenerateFlow'
 
 @Component
 export default class DotEditor extends Vue {
-  get dots (): Dot[] {
-    let stuntsheet: Stuntsheet = this.$store.state.selectedSS
-    return stuntsheet.dots
+  get dotsPairs (): [Dot, Dot|null][] {
+    let fromDots: Dot[] = this.$store.getters.getSelectedFromDots
+    let toDots: Array<Dot|null> = this.$store.getters.getSelectedToDots
+    return fromDots.map((dot: Dot, index: number) => [dot, toDots.length > index ? toDots[index] : null])
   }
 
-  isSelected (dot: Dot) {
-    return this.$store.state.selectedDots.includes(dot)
+  get dotTypesLength (): number {
+    return this.$store.getters.getSelectedSS.dotTypes.length
   }
 
-  setSelectedDots (dots: Dot[]) {
-    this.$store.commit('setSelectedDots', dots)
+  generateFlowHelper (index: number) {
+    generateFlow(
+      this.$store.state.show,
+      this.$store.state.selectedSSIndex,
+      [this.$store.getters.getSelectedFromDots[index]]
+    )
   }
 }
 </script>
@@ -65,9 +72,5 @@ table {
 
 th {
   border: 1px solid gray;
-}
-
-.selected {
-  background: aqua;
 }
 </style>

--- a/src/components/DotTypeEditor.vue
+++ b/src/components/DotTypeEditor.vue
@@ -2,9 +2,9 @@
   <div>
     <h2>Dot Type Editor</h2>
     <p>After configuring continuities, click "Generate Flows."</p>
-    <button v-on:click="addDotType">Add Dot Type</button>
     <div v-for="(dotType, dotTypeIndex) in dotTypes" v-bind:key="dotTypeIndex">
       <h3>Dot Type: {{dotTypeIndex}}</h3>
+      <button v-on:click="removeDotType(dotTypeIndex)">Remove Dot Type</button>
       <table>
         <thead>
           <tr>
@@ -22,7 +22,7 @@
           >
             <td>{{continuity.toString()}}</td>
             <td>
-              <select v-model="continuity.marchType">
+              <select v-model="continuity.marchType" v-on:change="generateFlowHelper(dotTypeIndex)">
                 <option
                 v-for="(marchType, marchTypeIndex) in marchTypes"
                 v-bind:key="marchTypeIndex"
@@ -32,7 +32,7 @@
               </select>
             </td>
             <td>
-              <select v-model="continuity.direction">
+              <select v-model="continuity.direction" v-on:change="generateFlowHelper(dotTypeIndex)">
                 <option
                 v-for="(direction, directionIndex) in directions"
                 v-bind:key="directionIndex"
@@ -59,9 +59,8 @@
           </tr>
         </tbody>
       </table>
-      <button v-on:click="generateFlow(dotTypeIndex)">Generate Flows</button>
-      <button v-on:click="removeDotType(dotTypeIndex)">Remove Dot Type</button>
     </div>
+    <button v-on:click="addDotType">Add Dot Type</button>
   </div>
 </template>
 
@@ -74,7 +73,7 @@ import generateFlow from '@/logic/GenerateFlow'
 @Component
 export default class BottomMenu extends Vue {
   get dotTypes (): Continuity[][] {
-    return this.$store.state.selectedSS.dotTypes
+    return this.$store.getters.getSelectedSS.dotTypes
   }
 
   get marchTypes () {
@@ -85,35 +84,33 @@ export default class BottomMenu extends Vue {
     return Directions
   }
 
-  addContinuity (dotTypeIndex: number) {
-    this.$store.state.selectedSS.dotTypes[dotTypeIndex]
-      .push(new Continuity(undefined, undefined, undefined))
-  }
-
-  removeContinuity (dotTypeIndex: number, continuityIndex: number) {
-    this.$store.state.selectedSS.dotTypes[dotTypeIndex]
-      .splice(continuityIndex, 1)
-  }
-
-  generateFlow (dotTypeIndex: number) {
-    let selectedSSIndex: number = this.$store.state.show.stuntSheets.indexOf(
-      this.$store.state.selectedSS
-    )
-    let dotTypeDots: Dot[] = this.$store.state.selectedSS.dots
+  generateFlowHelper (dotTypeIndex: number) {
+    let dotTypeDots: Dot[] = this.$store.getters.getSelectedSS.dots
       .filter((dot: Dot) => {
         return dotTypeIndex === dot.dotType
       })
-    generateFlow(this.$store.state.show, selectedSSIndex, dotTypeDots)
+    generateFlow(this.$store.state.show, this.$store.state.selectedSSIndex, dotTypeDots)
+  }
+
+  addContinuity (dotTypeIndex: number) {
+    this.$store.getters.getSelectedSS.dotTypes[dotTypeIndex]
+      .push(new Continuity(undefined, undefined, undefined))
+    this.generateFlowHelper(dotTypeIndex)
+  }
+
+  removeContinuity (dotTypeIndex: number, continuityIndex: number) {
+    this.$store.getters.getSelectedSS.dotTypes[dotTypeIndex]
+      .splice(continuityIndex, 1)
+    this.generateFlowHelper(dotTypeIndex)
   }
 
   addDotType () {
-    this.$store.state.selectedSS.dotTypes
+    this.$store.getters.getSelectedSS.dotTypes
       .push([new Continuity(undefined, undefined, undefined)])
   }
 
   removeDotType (dotTypeIndex: number) {
-    this.$store.state.selectedSS.dotTypes
-      .splice(dotTypeIndex, 1)
+    this.$store.getters.getSelectedSS.dotTypes.splice(dotTypeIndex, 1)
   }
 }
 </script>

--- a/src/components/Grapher.vue
+++ b/src/components/Grapher.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="grapher">
-    <GrapherDot v-for="(dot, index) in dots" v-bind:dot="dot" v-bind:key="index" />
+    <GrapherDot v-for="(dot, index) in toDots" v-bind:dot="dot" v-bind:key="-index - 1" v-bind:index="index" isTo />
+    <GrapherDot v-for="(dot, index) in fromDots" v-bind:dot="dot" v-bind:key="index" v-bind:index="index" />
   </div>
 </template>
 
@@ -17,9 +18,12 @@ import Stuntsheet from '@/models/Stuntsheet'
   }
 })
 export default class Grapher extends Vue {
-  get dots () {
-    let stuntsheet: Stuntsheet = this.$store.state.selectedSS
-    return stuntsheet.dots
+  get fromDots (): Dot[] {
+    return this.$store.getters.getSelectedSSDots
+  }
+
+  get toDots (): Array<Dot|null> {
+    return this.$store.getters.getSelectedSSNextDots
   }
 }
 </script>

--- a/src/components/GrapherDot.vue
+++ b/src/components/GrapherDot.vue
@@ -1,11 +1,11 @@
 <template>
   <span
     class="dot-wrapper"
-    v-bind:class="{'selected': isSelected}"
+    v-bind:class="{'selected': isSelected(), 'is-to': isTo}"
     v-bind:style="{top: coord[1] + 'em', left: coord[0] + 'em'}"
     v-on:click="selectDot"
   >
-    <span class="dot-label">{{key}}</span>
+    <span class="dot-label">{{index}}</span>
     <span class="dot-circle"/>
   </span>
 </template>
@@ -17,23 +17,24 @@ import Dot from '@/models/Dot'
 @Component
 export default class GrapherDot extends Vue {
   @Prop(Dot) readonly dot!: Dot
-  key = -1;
+  @Prop(Boolean) readonly isTo!: boolean
+  @Prop(Number) readonly index!: number
 
   get coord (): number[] {
     let selectedBeat: number = this.$store.state.selectedBeat
-    if (this.dot.flow.length >= selectedBeat) {
+    if (selectedBeat >= 0 && selectedBeat < this.dot.flow.length) {
       return this.dot.flow[selectedBeat]
     } else {
       return this.dot.flow[this.dot.flow.length - 1]
     }
   }
 
-  get isSelected (): boolean {
-    return this.$store.state.selectedDots.includes(this.dot)
+  selectDot () {
+    this.$store.commit('setSelectedDotsIndex', [this.index])
   }
 
-  selectDot () {
-    this.$store.commit('setSelectedDots', [this.dot])
+  isSelected (): boolean {
+    return this.$store.state.selectedDotsIndex.includes(this.index)
   }
 }
 </script>
@@ -43,16 +44,23 @@ export default class GrapherDot extends Vue {
   display: inline-block;
   position: absolute;
   transform: translate(-50%, -50%);
+  opacity: 0.3;
 
   &.selected {
     border: 0.125em solid aqua;
+    opacity: 1.0;
   }
+
+  &.is-to .dot-circle {
+    background: red;
+  }
+
 }
 
 .dot-wrapper, .dot-circle {
   width: 1em;
   height: 1em;
-  border-radius: 0.5em;
+  border-radius: 1em;
 }
 
 .dot-circle {

--- a/src/components/SSEditor.vue
+++ b/src/components/SSEditor.vue
@@ -12,8 +12,8 @@
       </thead>
       <tbody>
         <tr
-        v-bind:class="{'selected': index === selectedSSIndex}"
         v-for="(stuntsheet, index) in stuntSheets"
+        v-bind:class="{'selected': index === selectedSSIndex}"
         v-bind:key="index"
         >
           <td>{{index}}</td>
@@ -53,13 +53,11 @@ export default class SSEditor extends Vue {
   }
 
   get selectedSSIndex () {
-    return this.$store.state.show.stuntSheets.indexOf(
-      this.$store.state.selectedSS
-    )
+    return this.$store.state.selectedSSIndex
   }
 
   selectSS (index: number) {
-    this.$store.commit('setSelectedSS', index)
+    this.$store.commit('setSelectedSSIndex', index)
   }
 
   removeSS (index: number) {

--- a/src/logic/GenerateFlow.ts
+++ b/src/logic/GenerateFlow.ts
@@ -35,19 +35,20 @@ const generateFlow = function (show: Show, stuntsheetIndex: number, dots: Dot[])
   var toSS = show.stuntSheets[stuntsheetIndex + 1]
 
   dots.forEach(function (fromDot: Dot) {
-    if (fromDot.nextDot === null) return
+    if (!fromDot.hasNextDot) return
 
-    var toDot: Dot = fromDot.nextDot
+    let fromIndex = fromSS.dots.indexOf(fromDot)
+    var toDot: Dot = toSS.dots[fromIndex]
     var continuities: Continuity[] = fromSS.dotTypes[fromDot.dotType]
     var flow: number[][] = [fromDot.coord]
 
-    continuities.forEach(function (continuity: Continuity, index: number) {
+    continuities.forEach(function (continuity: Continuity, toIndex: number) {
       if (flow[flow.length - 1] === toDot.coord) return
 
       if (continuity.marchType === MarchTypes.MTHS) {
         // MTHS
         if (continuity.beats === null) return
-        let i = index === 0 ? 1 : 0
+        let i = toIndex === 0 ? 1 : 0
         for (; i < continuity.beats; i++) {
           flow.push(flow[flow.length - 1])
         }

--- a/src/models/Dot.ts
+++ b/src/models/Dot.ts
@@ -2,17 +2,18 @@
  * Represents a marcher's starting position in
  * a Stuntsheet and how they will reach the
  * next Stuntsheet.
+ *
  * Flow should be set by GenerateFlow.
  */
 class Dot {
-  dotType: number;
-  coord: number[];
-  flow: number[][];
-  nextDot: Dot|null;
+  dotType: number; // Defines which continuities to do
+  coord: number[]; // (x, y) coordinates
+  flow: number[][]; // (x, y) coordinates for each beat in time
+  hasNextDot: boolean; // This dot is connected to the next stuntsheet's dot in the same index
 
   constructor (prevDot: Dot|undefined, coord: number[]|undefined) {
     this.dotType = 0
-    this.nextDot = null
+    this.hasNextDot = false
     if (prevDot === undefined) {
       this.coord = coord !== undefined ? coord : [0, 0]
       this.flow = [this.coord]
@@ -20,19 +21,9 @@ class Dot {
       let flow = prevDot.flow
       this.coord = flow[flow.length - 1].slice()
       this.flow = [this.coord]
-      prevDot.nextDot = this
+      prevDot.hasNextDot = true
     }
   }
-
-  flowIsValid (): boolean {
-    if (this.flow[0][0] !== this.coord[0] &&
-      this.flow[0][1] !== this.coord[1]) { return false }
-
-    if (this.nextDot === null) { return this.flow.length === 1 }
-
-    return this.flow[this.flow.length - 1][0] === this.nextDot.coord[0] &&
-      this.flow[this.flow.length - 1][1] === this.nextDot.coord[1]
-  };
 }
 
 export default Dot

--- a/src/models/Show.ts
+++ b/src/models/Show.ts
@@ -30,26 +30,13 @@ export class Show {
    * and work on the flows.
    */
   unsetNextDots (stuntsheetIndex: number): void {
-    this.stuntSheets[stuntsheetIndex].dots.forEach(function (dot: Dot) {
-      dot.nextDot = null
-      dot.flow = [dot.coord]
+    this.stuntSheets[stuntsheetIndex].dots.forEach(function (dot: Dot, index: number) {
+      if (dot.hasNextDot) {
+        dot.flow = [dot.coord]
+        dot.hasNextDot = false
+      }
     })
   };
-
-  /*
-   * Helper function that generates a new list of Dots
-   * in the next Stuntsheet with each position corresponding
-   * to the last position of a flow.
-   * Helpful if author wants to focus on setting Dots'
-   * flows rather than worry about the next coordinates.
-   */
-  attachToNextSS (stuntsheetIndex: number): void {
-    let nextDots: Dot[] = []
-    this.stuntSheets[stuntsheetIndex].dots.forEach(function (dot) {
-      nextDots.push(new Dot(dot, undefined))
-    })
-    this.stuntSheets[stuntsheetIndex + 1].dots = nextDots
-  }
 };
 
 /*

--- a/src/models/Stuntsheet.ts
+++ b/src/models/Stuntsheet.ts
@@ -6,9 +6,9 @@ import Dot from './Dot'
  * generate each dots' flows to their nextDot.
  */
 class Stuntsheet {
-  beats: number;
-  dotTypes: Continuity[][];
-  dots: Dot[];
+  beats: number; // Number of beats
+  dotTypes: Continuity[][]; // Dot Types represent the list of continuities a dot does
+  dots: Dot[]; // The index of each dot is their unique identifier
 
   constructor (
     beats: number|undefined,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import { Show, ShowLabels } from '@/models/Show'
 import Dot from '@/models/Dot'
+import Stuntsheet from '@/models/Stuntsheet'
 
 Vue.use(Vuex)
 
@@ -9,21 +10,19 @@ const defaultShow = new Show('Example Show', 10, ShowLabels[0])
 
 export default new Vuex.Store({
   state: {
-    selectedDots: [defaultShow.stuntSheets[0].dots[0]],
-    selectedSS: defaultShow.stuntSheets[0],
-    selectedDotType: 0,
+    selectedDotsIndex: [0],
+    selectedSSIndex: 0,
     selectedBeat: 0,
     show: defaultShow,
     zoomLevel: 100
   },
   mutations: {
-    setSelectedDots (state, dots: Dot[]) {
-      state.selectedDots = dots
+    setSelectedDotsIndex (state, dots: number[]) {
+      state.selectedDotsIndex = dots
     },
-    setSelectedSS (state, index: number) {
-      state.selectedSS = state.show.stuntSheets[index]
-      state.selectedDots = [state.selectedSS.dots[0]]
-      state.selectedDotType = 0
+    setSelectedSSIndex (state, index: number) {
+      state.selectedSSIndex = index
+      state.selectedDotsIndex = []
       state.selectedBeat = 0
     },
     setZoomLevel (state, level: number) {
@@ -34,5 +33,35 @@ export default new Vuex.Store({
     }
   },
   actions: {
+  },
+  getters: {
+    getSelectedFromDots: state => {
+      return state.show.stuntSheets[state.selectedSSIndex].dots
+        .filter((dot: Dot, index: number) => state.selectedDotsIndex.includes(index))
+    },
+    getSelectedToDots: state => {
+      console.log(state.selectedSSIndex + 1)
+      console.log(state.show.stuntSheets.length)
+      if (state.show.stuntSheets.length <= state.selectedSSIndex + 1) {
+        return []
+      }
+      return state.show.stuntSheets[state.selectedSSIndex + 1].dots
+        .filter((dot: Dot, index: number) => state.selectedDotsIndex.includes(index))
+    },
+    getSelectedSS: state => {
+      return state.show.stuntSheets[state.selectedSSIndex]
+    },
+    getSelectedSSDots: state => {
+      return state.show.stuntSheets[state.selectedSSIndex].dots
+    },
+    getSelectedSSNextDots: state => {
+      if (state.show.stuntSheets.length <= state.selectedSSIndex + 1) {
+        return []
+      }
+      return state.show.stuntSheets[state.selectedSSIndex + 1].dots
+        .map((dot: Dot, index: number) => {
+          return (state.show.stuntSheets[state.selectedSSIndex].dots[index].hasNextDot) ? dot : null
+        })
+    }
   }
 })

--- a/tests/unit/logic/GenerateFlow.spec.ts
+++ b/tests/unit/logic/GenerateFlow.spec.ts
@@ -17,7 +17,6 @@ describe('GenerateFlow', () => {
     generateFlow(show, 0, [firstSSDot])
     expect(firstSSDot.flow).toHaveLength(1)
     expect(firstSSDot.flow).toEqual([firstSSDot.coord])
-    expect(firstSSDot.flowIsValid()).toBe(true)
   })
 
   describe('FHS', () => {
@@ -45,7 +44,6 @@ describe('GenerateFlow', () => {
         [firstSSDot.coord[0] + 1, firstSSDot.coord[1] + 2],
         secondSSDot.coord
       ])
-      expect(firstSSDot.flowIsValid()).toBe(true)
     })
 
     test('FHS NS/EW', () => {
@@ -63,7 +61,6 @@ describe('GenerateFlow', () => {
         [firstSSDot.coord[0] + 2, firstSSDot.coord[1] + 1],
         secondSSDot.coord
       ])
-      expect(firstSSDot.flowIsValid()).toBe(true)
     })
   })
 
@@ -100,7 +97,6 @@ describe('GenerateFlow', () => {
         [firstSSDot.coord[0] + 1, firstSSDot.coord[1] + 2],
         secondSSDot.coord
       ])
-      expect(firstSSDot.flowIsValid()).toBe(true)
     })
 
     test('another MTHS', () => {
@@ -119,7 +115,6 @@ describe('GenerateFlow', () => {
         firstSSDot.coord,
         firstSSDot.coord
       ])
-      expect(firstSSDot.flowIsValid()).toBe(false)
     })
   })
 })

--- a/tests/unit/models/Dot.spec.ts
+++ b/tests/unit/models/Dot.spec.ts
@@ -5,8 +5,7 @@ test('initializing Dot with no previous Dot', () => {
   expect(dot.dotType).toBe(0)
   expect(dot.coord).toEqual([1.5, 2])
   expect(dot.flow).toEqual([[1.5, 2]])
-  expect(dot.nextDot).toBeNull()
-  expect(dot.flowIsValid()).toBe(true)
+  expect(dot.hasNextDot).toBe(false)
 })
 
 describe('initializing Dot with previous Dot', () => {
@@ -26,22 +25,7 @@ describe('initializing Dot with previous Dot', () => {
     expect(secondSSDot.dotType).toBe(0)
     expect(secondSSDot.coord).toEqual([firstSSDot.coord[0] + 1.0, firstSSDot.coord[1] + 1.0])
     expect(secondSSDot.flow).toEqual([secondSSDot.coord])
-    expect(secondSSDot.nextDot).toBeNull()
-    expect(secondSSDot.flowIsValid()).toBe(true)
-    expect(firstSSDot.nextDot).toBe(secondSSDot)
+    expect(secondSSDot.hasNextDot).toBe(false)
+    expect(firstSSDot.hasNextDot).toBe(true)
   })
-})
-
-test('Dot validates if flow is correct', () => {
-  let firstSSDot = new Dot(undefined, [1, 1])
-  let secondSSDot = new Dot(firstSSDot, undefined)
-  expect(firstSSDot.flowIsValid()).toBe(true)
-  secondSSDot.coord = [2, 2]
-  expect(firstSSDot.flowIsValid()).toBe(false)
-  firstSSDot.flow = [[1, 1], [2, 2]]
-  expect(firstSSDot.flowIsValid()).toBe(true)
-  firstSSDot.nextDot = null
-  expect(firstSSDot.flowIsValid()).toBe(false)
-  firstSSDot.flow = [[1, 1]]
-  expect(firstSSDot.flowIsValid()).toBe(true)
 })

--- a/tests/unit/models/Show.spec.ts
+++ b/tests/unit/models/Show.spec.ts
@@ -1,5 +1,6 @@
 import { Show, ShowLabels } from '@/models/Show'
 import Stuntsheet from '@/models/Stuntsheet'
+import Dot from '@/models/Dot'
 
 test('Show LABELS is correct', () => {
   expect(ShowLabels[0].toString()).toBe('1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274,275,276,277,278,279,280,281,282,283,284,285,286,287,288,289,290,291,292,293,294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,320,321,322,323,324,325,326,327,328,329,330,331,332,333,334,335,336,337,338,339,340,341,342,343,344,345,346,347,348,349,350,351,352,353,354,355,356,357,358,359,360,361,362,363,364,365,366,367,368,369,370,371,372,373,374,375,376,377,378,379,380,381,382,383,384,385,386,387,388,389,390,391,392,393,394,395,396,397,398,399,400')
@@ -26,31 +27,16 @@ describe('Show', () => {
     expect(show.stuntSheets[0].dots).toHaveLength(10)
     expect(show.stuntSheets[1].dots).toHaveLength(10)
     expect(show.stuntSheets[1].beats).toBe(16)
-    show.stuntSheets[0].dots.forEach(function (dot) {
-      expect(dot.nextDot).not.toBeNull()
-      expect(dot.coord).toEqual(dot.nextDot !== null && dot.nextDot.coord)
+    show.stuntSheets[0].dots.forEach(function (dot: Dot, index: number) {
+      expect(dot.coord).toEqual(show.stuntSheets[1].dots[index].coord)
+      expect(dot.hasNextDot).toBe(true)
     })
   })
 
   test('unsetNextDots()', () => {
     show.unsetNextDots(0)
-    show.stuntSheets[0].dots.forEach(function (dot) {
-      expect(dot.nextDot).toBeNull()
-      expect(dot.flow).toEqual([dot.coord])
-      expect(dot.flowIsValid()).toBe(true)
-    })
-  })
-
-  test('attachToNextSS', () => {
-    show.stuntSheets[0].dots.forEach(function (dot) {
-      dot.flow = [dot.coord, [dot.coord[0] + 1, dot.coord[1] + 1]]
-    })
-
-    show.attachToNextSS(0)
-    show.stuntSheets[0].dots.forEach(function (dot) {
-      expect(dot.nextDot).not.toBeNull()
-      expect(dot.flow[1]).toEqual(dot.nextDot !== null && dot.nextDot.coord)
-      expect(dot.flowIsValid()).toBe(true)
+    show.stuntSheets[0].dots.forEach((dot: Dot) => {
+      expect(dot.hasNextDot).toBe(false)
     })
   })
 })

--- a/tests/unit/models/Stuntsheet.spec.ts
+++ b/tests/unit/models/Stuntsheet.spec.ts
@@ -30,11 +30,12 @@ describe('initializing Stuntsheet with previous Stuntsheet', () => {
   test('previous Stuntsheet has nextDot', () => {
     let x = 0
     let y = 0
-    prevSS.dots.forEach(function (dot) {
+    prevSS.dots.forEach(function (dot: Dot, index: number) {
       expect(dot.dotType).toBe(0)
       expect(dot.coord).toEqual([x, y])
       expect(dot.flow).toEqual([[x, y]])
-      expect(newSS.dots).toEqual(expect.arrayContaining([dot.nextDot]))
+      expect(dot.hasNextDot).toBe(true)
+      expect(newSS.dots[index].coord).toEqual(dot.coord)
       x += 2
     })
   })
@@ -46,11 +47,10 @@ describe('initializing Stuntsheet with previous Stuntsheet', () => {
     expect(newSS.dots).toHaveLength(10)
     let x = 0
     let y = 0
-    newSS.dots.forEach(function (dot) {
+    newSS.dots.forEach(function (dot: Dot) {
       expect(dot.dotType).toBe(0)
       expect(dot.coord).toEqual([x, y])
       expect(dot.flow).toEqual([[x, y]])
-      expect(dot.nextDot).toBeNull()
       x += 2
     })
   })


### PR DESCRIPTION
- Show the next position as a red dot and in the Dot Editor
- Refactor the store and `Dot` to use the index of references to dot, stuntsheet, etc. rather than storing a pointer to the object. This should allow for better saving/loading when it gets serialized to JSON (there are no pointers in JSON).
  - In `Dot`, use a boolean `hasNextDot` to denote if it is connected to the next Stuntsheet's dot at the same index. This removes any possible issues with syncing `dot.nextDot` and the actual next dot.
- Remove "Generate Flows" button and update flows upon changing dots or continuities
- Rearrange Dot Type Editor "Add Dot Type" button to be at bottom to make more sense with scrolling
- Set `min` and `max` in `input` elements where possible